### PR TITLE
Fix build with Lua 5.4

### DIFF
--- a/src/addonloader/luahelper.h
+++ b/src/addonloader/luahelper.h
@@ -90,6 +90,13 @@ int LuaReturn(LuaState *s, const std::tuple<Args...> &args) {
 constexpr char kLuaModuleName[] = "__fcitx_luaaddon";
 
 LuaAddonState *GetLuaAddonState(lua_State *lua);
+    
+// These functions are required for GetLuaAddonState.
+extern decltype(&::lua_getglobal) _fcitx_lua_getglobal;
+extern decltype(&::lua_touserdata) _fcitx_lua_touserdata;
+extern decltype(&::lua_settop) _fcitx_lua_settop;
+extern decltype(&::lua_close) _fcitx_lua_close;
+extern decltype(&::luaL_newstate) _fcitx_luaL_newstate;
 
 FCITX_DECLARE_LOG_CATEGORY(lua_log);
 #define FCITX_LUA_INFO() FCITX_LOGC(::fcitx::lua_log, Info)


### PR DESCRIPTION
Partly revert https://github.com/fcitx/fcitx5-lua/commit/17c57a79a550a1f94b12a3279e6014ce0f8f1b4e to pass build in Arch. Fixes #2.