### PR TITLE
Only resolve lua soname if USE_DLOPEN.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,9 @@ function(_RESOLVE_LIBRARY_PATH _FILE_NAME _LIBRARY_PATH)
     set(${_FILE_NAME} ${_FILE_NAME_OUT} PARENT_SCOPE)
 endfunction()
 
-_RESOLVE_LIBRARY_PATH(LUA_LIBRARY_PATH  ${LUA_LIBRARY})
+if(USE_DLOPEN)
+    _RESOLVE_LIBRARY_PATH(LUA_LIBRARY_PATH  ${LUA_LIBRARY})
+endif()
 
 configure_file(config.h.in config.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
e6a55fa assums `LUA_LIBRARY` to be a dynamic library, and use `objdump` to resolve its path. But Android tend to use static library `liblua.a`, and `objdump` yeilds different output:

```console
$ objdump -p lua/arm64-v8a/lib/liblua.a
In archive lua/arm64-v8a/lib/liblua.a:

lapi.c.o:     file format elf64-little


lcode.c.o:     file format elf64-little


lctype.c.o:     file format elf64-little
...
```