### PR TITLE
fix unused luaLibrary_ warning

### DIFF
--- a/src/addonloader/luastate.cpp
+++ b/src/addonloader/luastate.cpp
@@ -20,7 +20,14 @@
 
 namespace fcitx {
 LuaState::LuaState(Library *library)
-    : luaLibrary_(library), state_(nullptr, _fcitx_lua_close) {
+    :
+#ifdef USE_DLOPEN
+      luaLibrary_(library),
+#endif
+      state_(nullptr, _fcitx_lua_close) {
+#ifndef USE_DLOPEN
+    FCITX_UNUSED(library);
+#endif
     // Resolve all required lua function first.
 #define FOREACH_LUA_FUNCTION(NAME)                                             \
     FILL_LUA_API(NAME);                                                        \

--- a/src/addonloader/luastate.h
+++ b/src/addonloader/luastate.h
@@ -7,6 +7,7 @@
 #ifndef _FCITX5_LUA_ADDONLOADER_LUASTATE_H_
 #define _FCITX5_LUA_ADDONLOADER_LUASTATE_H_
 
+#include "config.h"
 #include "luastate_details.h"
 #include <fcitx-utils/library.h>
 #include <functional>
@@ -29,7 +30,9 @@ public:
     }
 
 private:
+#ifdef USE_DLOPEN
     Library *luaLibrary_;
+#endif
 
 #define FOREACH_LUA_FUNCTION DECLARE_LUA_FUNCTION_PTR
 #include "luafunc.h"


### PR DESCRIPTION
```
In file included from /Users/runner/work/fcitx5-ios/fcitx5-ios/engines/fcitx5-lua/src/addonloader/luastate.cpp:7:
/Users/runner/work/fcitx5-ios/fcitx5-ios/engines/fcitx5-lua/src/addonloader/luastate.h:32:14: warning: private field 'luaLibrary_' is not used [-Wunused-private-field]
   32 |     Library *luaLibrary_;
      |              ^
1 warning generated.
```